### PR TITLE
Using page size param in search

### DIFF
--- a/bitbucket_connector.py
+++ b/bitbucket_connector.py
@@ -1,6 +1,8 @@
 import requests
 import base64
 
+MAX_PAGE_LENGTH = 100
+
 class BitbucketRepository:
 
   def __init__(self, name, url):
@@ -31,10 +33,12 @@ class BitbucketConnector:
     return results
 
   def get_repositories(self, query, limit):
+    page_length = min(limit, MAX_PAGE_LENGTH)
     params = {
         "q": f"slug~\"{query}\" OR name~\"{query}\"",
         "fields": "values.slug,values.links.html.href,next,page",
-        "sort": "-updated_on"
+        "sort": "-updated_on",
+        "pagelen": page_length
     }
     repositories = self.handle_query(f"https://api.bitbucket.org/2.0/repositories/{self.workspace}", params, limit)
     return [BitbucketRepository(repo.get("slug"), repo.get("links").get("html").get("href")) for repo in repositories]

--- a/bitbucket_connector.py
+++ b/bitbucket_connector.py
@@ -32,7 +32,7 @@ class BitbucketConnector:
         return self.handle_query(url, params, limit, results)
     return results
 
-  def get_repositories(self, query, limit):
+  def get_repositories(self, query, limit = 15):
     page_length = min(limit, MAX_PAGE_LENGTH)
     params = {
         "q": f"slug~\"{query}\" OR name~\"{query}\"",


### PR DESCRIPTION
- By default, Bitbucket search endpoints paginate results with a page size of 10, just below the maximum desired by the plugin (15). In queries with many results, this would require more than one roundtrip.
- Using "pagelen" parameter we can request up to 100 results per page, more than enough to fill the screen with results if we wanted it.